### PR TITLE
Fix bug where invalid control digit was returned

### DIFF
--- a/src/personnummer.cpp
+++ b/src/personnummer.cpp
@@ -74,7 +74,9 @@ int luhn(std::string::iterator begin, std::string::iterator end) {
       sum -= 10;
   }
 
-  return 10 - (sum % 10);
+  int checksum = 10 - (sum % 10);
+
+  return checksum == 10 ? 0 : checksum;
 }
 
 /*

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -60,6 +60,7 @@ TEST_CASE("Validate social security number", "[pnr]") {
       TestDate("196408233234", true),  TestDate("0001010107", true),
       TestDate("000101-0107", true),   TestDate("640327-381", false),
       TestDate("6403273814", false),   TestDate("640327-3814", false),
+      TestDate("19090903-6600", true),
   };
 
   for (const auto &tc : cases) {
@@ -77,6 +78,7 @@ TEST_CASE("Validate luhn", "[luhn]") {
   std::map<std::string, int> cases = {
       {"900101001", 7}, {"640327381", 3}, {"640823323", 4},
       {"000101010", 7}, {"510818916", 7}, {"130401293", 1},
+      {"090903660", 0},
   };
 
   for (const auto &tc : cases) {


### PR DESCRIPTION
This resolves a bug where invalid checksum was returned from Luhn method. Tests added to ensure correctness.

The reason why I implement the Luhn algoritm by returning the control digit instead of a boolean is because I want to be able to generate fake social security numbers (now or in the future depending on which library is used). By returning the control digit, one could create a fake ssn like this:

```cpp
int control = luhn("750101123") // Valid SSN is 750101-123{control}
```

Based on this I rather fix the bug by checking the control digit instead of simplifying the method like e.g the [python](https://github.com/personnummer/python/blob/master/personnummer/personnummer.py#L161-L175) implementation.